### PR TITLE
Allow filename in constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,29 @@ $twig->addExtension($asset_rev);
 }
 ```
 
+## Symfony usage
+
+You can register the extension automatically in Symfony via `app/config/services.yml`.
+
+``` yml
+twig.extension.asset_rev:
+  class: M1\TwigAssetRevExtension\TwigAssetRevExtension
+  arguments: [ "%kernel.root_dir%/../web/js/manifest.json", false ]
+  tags:
+    - { name: twig.extension }
+```
+
 ## Setup
 
 ```php
-new TwigAssetRevExtension(array $assets [, bool $minified = true ] )
+new TwigAssetRevExtension(mixed $assets [, bool $minified = true ] )
 ```
 
 #### Parameters
+
 ##### assets
-The array of assets and rev'd assets, an example:
+
+The path to the JSON file, or the array of assets and rev'd assets, an example:
 
 ```php
 array(

--- a/src/TwigAssetRevExtension.php
+++ b/src/TwigAssetRevExtension.php
@@ -49,11 +49,17 @@ class TwigAssetRevExtension extends \Twig_Extension
     /**
      * The TwigAssetRevExtension constructor
      *
-     * @param array $assets   The array of assets and rev'd assets
+     * @param mixed $assets   The array of assets and rev'd assets
      * @param bool  $minified Whether to search for minified rev'd assets
      */
-    public function __construct(array $assets, $minified = true)
+    public function __construct($assets, $minified = true)
     {
+        if (!is_array($assets)) {
+            if (is_file($assets)) {
+                $assets = json_decode(file_get_contents($assets), true);
+            }
+        }
+
         $this->assets = $assets;
         $this->minified = $minified;
     }
@@ -111,7 +117,7 @@ class TwigAssetRevExtension extends \Twig_Extension
                 )
             ? $this->assets[$min] : false;
     }
-    
+
     /**
      * Returns the name of the extension.
      *

--- a/tests/TwigAssetRevExtensionTest.php
+++ b/tests/TwigAssetRevExtensionTest.php
@@ -41,6 +41,33 @@ class TwigAssetRevExtensionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFileAsArgument()
+    {
+        $expected_assets = array(
+            "css/app.css" => "css/app.min.9f8d3d255c1f.css",
+            "js/app.admin.js" => "js/app.admin.min.dbdc6d8e2114.js",
+            "js/app.admin.plugins.js" => "js/app.admin.plugins.min.283a1a903f4a.js",
+            "img/image-jpg.jpg" => "img/image-jpg.219a48cfe072.jpg",
+            "img/image-png.png" => "img/image-png.1691620d298a.png",
+            "img/image-gif.gif" => "img/image-gif.bcd9f17c5cf8.png"
+        );
+
+        $loader_array = array();
+
+        foreach (array_keys($expected_assets) as $raw_asset) {
+            $loader_array[$raw_asset] = $this->makeAssetTwigString($raw_asset);
+        }
+
+        $loader = new \Twig_Loader_Array($loader_array);
+
+        $twig = new \Twig_Environment($loader);
+        $twig->addExtension(new \M1\TwigAssetRevExtension\TwigAssetRevExtension(__DIR__.'/stub/rev-manifest.json'));
+
+        foreach ($expected_assets as $raw_asset => $rev_asset) {
+            $this->assertEquals($rev_asset, $twig->render($raw_asset));
+        }
+    }
+
     public function testNoMinAsset()
     {
         $file = 'css/app.css';


### PR DESCRIPTION
Hello, 

Nice extension, but I struggled to use it in Symfony out of the box. 

With a small change it is now possible to specify the filename in the constructor and also register it as a Symfony service. 